### PR TITLE
removed spurious Latin-1 char in qwiic_kx13x.py

### DIFF
--- a/qwiic_kx13x.py
+++ b/qwiic_kx13x.py
@@ -328,8 +328,8 @@ class QwiicKX13XCore(object):
         """
             This functions controls the accelerometers power on and off state.
             :param enable: True or false indicating power on or off
-            respectively. 
-            :return: Returns false when an incorrect argumen has been passed.
+            respectively
+            :return: Returns false when an incorrect argument has been passed.
             :rtype: bool
         """
         if enable != True and enable != False:


### PR DESCRIPTION
Was causing this error on Linux:

    SyntaxError: (unicode error) 'utf-8' codec can't decode byte 0xa0 in position 173: invalid start byte

which broke the entire qwiic_py installation on my Raspberry Pi